### PR TITLE
Bug fix for AddPortMapping and DeletePortMapping actions

### DIFF
--- a/lib/src/service.dart
+++ b/lib/src/service.dart
@@ -143,7 +143,7 @@ class Service {
     var request = await UpnpCommon.httpClient.postUrl(Uri.parse(controlUrl));
     request.headers.set("SOAPACTION", '"${type}#${name}"');
     request.headers.set("Content-Type", 'text/xml; charset="utf-8"');
-    request.headers.set("User-Agent", 'CyberGarage-HTTP/1.0');
+    request.headers.set("Content-Length", body.runes.length);
     request.write(body);
     var response = await request.close();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Universal Plugin and Play Host/Client
 homepage: https://github.com/SpinlockLabs/upnp.dart
 dependencies:
   xml: "^4.5.1"
-  crypto: "^2.1.5"
+  crypto: ^3.0.1
 environment:
   sdk: ">=2.0.0 <3.0.0"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 2.0.1
 description: Universal Plugin and Play Host/Client
 homepage: https://github.com/SpinlockLabs/upnp.dart
 dependencies:
-  xml: "^4.5.1"
+  xml: "^5.3.1"
   crypto: ^3.0.1
 environment:
   sdk: ">=2.0.0 <3.0.0"


### PR DESCRIPTION
Content-Length is a required header (UPNP device architecture document: https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf), and was not present in the previous commit. Without the Content-Length header the AddPortMapping and DeletePortMapping actions return a 402 error. The User-Agent header is optional and was not important to my work so I removed it, but it can be added back if needed.